### PR TITLE
PEP-003: Fluent plugin API

### DIFF
--- a/nuun-io_pep_003_plugin_fluent_api.adoc
+++ b/nuun-io_pep_003_plugin_fluent_api.adoc
@@ -1,0 +1,22 @@
+|=======================
+|PEP       |  003
+|Title     |  Fluent plugins
+|Author    |  Adrien LAUER and Pierre THIROUIN
+|Status    |  draft
+|=======================
+
+
+= Abstract
+
+This PEP is about a new fluent API for plugins which could complement the traditional API (modernized with PEP 002 or not).
+This new API make uses of one-method interfaces to enable lambda coding in the plugins themselves. The API is still
+backwards compatible with Java 6 & 7.
+
+The result is a drastic reduction of boilerplate code and a simplification of the plugin interface (named FluentPlugin in
+this pep). The use of "closures" and the ability to install modules directly from the init method enable to avoid keeping
+state in the plugin itself.  
+
+= Specification
+
+This PEP is specified as a Proof-Of-Concept under the [pep_003_poc](pep_003_poc) directory. This should be compiled with
+Java 8, as the example plugins use lambda and streams (but plugins can be written without).

--- a/pep_003_poc/io/nuun/kernel/ComplexPlugin.java
+++ b/pep_003_poc/io/nuun/kernel/ComplexPlugin.java
@@ -1,0 +1,99 @@
+package io.nuun.kernel;
+
+import io.nuun.kernel.fluent.AbstractFluentPlugin;
+import io.nuun.kernel.fluent.Factory;
+import io.nuun.kernel.fluent.SomeTrait;
+import io.nuun.kernel.fluent.AbstractModule;
+import io.nuun.kernel.fluent.ConfigurationBuilder;
+import io.nuun.kernel.fluent.InitContext;
+import io.nuun.kernel.fluent.ModuleInstaller;
+import io.nuun.kernel.fluent.MyImplementationSpecification;
+import io.nuun.kernel.fluent.MyInterfaceSpecification;
+import io.nuun.kernel.fluent.PrivateModule;
+import io.nuun.kernel.fluent.SomeOtherTrait;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+// Plugin name is inferred from class name. i.e. complex-plugin from ComplexPlugin
+public class ComplexPlugin extends AbstractFluentPlugin {
+    public static final String PROPS = ".*\\.props";
+    public static final MyInterfaceSpecification MY_INTERFACE_SPECIFICATION = new MyInterfaceSpecification();
+    public static final MyImplementationSpecification MY_IMPLEMENTATION_SPECIFICATION = new MyImplementationSpecification();
+
+    @Override
+    public void configure(ConfigurationBuilder configurationBuilder) {
+        configurationBuilder
+                .after(SomeTrait.class) // replaces requiredPlugins
+                .before(SomeOtherTrait.class) // replaces dependentPlugins
+                .scanClasses(MY_INTERFACE_SPECIFICATION) // can use spec-DSL to build it
+                .scanResources(PROPS)
+                .addPackageRoot("org.seedstack")
+
+                .nextRound()
+
+                .scanClasses(MY_IMPLEMENTATION_SPECIFICATION); // can use spec-DSL to build it
+    }
+
+    @Override
+    public void init(final InitContext initContext, final ModuleInstaller moduleInstaller) {
+        final Map<Class<? extends Factory>, Set<Class<? extends Factory>>> factories = new HashMap<>();
+
+        // Rounds can be externalized to named classes and removing a lot of code from the plugin
+
+        initContext.round(() -> {
+            final Properties properties = new Properties();
+
+            initContext.trait(SomeTrait.class).doSomething();
+
+            initContext.resources(PROPS).forEach((url) -> {
+                try {
+                    properties.load(url.openStream());
+                } catch (IOException e) {
+                    throw new IllegalStateException("Unable to load URL " + url);
+                }
+            });
+
+            initContext.classes(MY_INTERFACE_SPECIFICATION).forEach((factoryInterface) -> factories.put(factoryInterface, new HashSet<>()));
+
+            moduleInstaller.install(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(Properties.class).toInstance(properties);
+                }
+            });
+        });
+
+
+        initContext.round(() -> {
+            initContext.classes(MY_IMPLEMENTATION_SPECIFICATION).forEach((factoryImplementation) -> factories.get(findInterfaceForImpl(factoryImplementation)).add(factoryImplementation));
+
+            moduleInstaller.install(new PrivateModule() {
+                @Override
+                protected void configure() {
+                    factories.forEach((factoryInterface, factoryImplementations)
+                            -> factoryImplementations.forEach((factoryImpl)
+                            -> bind(factoryInterface).to(factoryImpl)));
+                }
+            });
+        });
+    }
+
+    @Override
+    public void start() {
+        // do something to start
+    }
+
+    @Override
+    public void stop() {
+        // do something to stop
+    }
+
+    private Class<? extends Factory> findInterfaceForImpl(Class<? extends Factory> implClass) {
+        return null;
+    }
+}

--- a/pep_003_poc/io/nuun/kernel/SimplePlugin.java
+++ b/pep_003_poc/io/nuun/kernel/SimplePlugin.java
@@ -1,0 +1,14 @@
+package io.nuun.kernel;
+
+import io.nuun.kernel.fluent.AbstractFluentPlugin;
+import io.nuun.kernel.fluent.MyInterfaceSpecification;
+import io.nuun.kernel.fluent.SomeTrait;
+import io.nuun.kernel.fluent.ConfigurationBuilder;
+import io.nuun.kernel.fluent.MyImplementationSpecification;
+
+public class SimplePlugin extends AbstractFluentPlugin {
+    @Override
+    public void configure(ConfigurationBuilder configurationBuilder) {
+        configurationBuilder.after(SomeTrait.class).bindClasses(new MyInterfaceSpecification(), new MyImplementationSpecification());
+    }
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/AbstractFluentPlugin.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/AbstractFluentPlugin.java
@@ -1,0 +1,23 @@
+package io.nuun.kernel.fluent;
+
+public class AbstractFluentPlugin implements FluentPlugin {
+    @Override
+    public void configure(ConfigurationBuilder configurationBuilder) {
+
+    }
+
+    @Override
+    public void init(InitContext initContext, ModuleInstaller moduleInstaller) {
+
+    }
+
+    @Override
+    public void start() {
+
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/AbstractModule.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/AbstractModule.java
@@ -1,0 +1,13 @@
+package io.nuun.kernel.fluent;
+
+public abstract class AbstractModule {
+    protected BindToClass bind(final Class<?> aClass) {
+        return new BindToClass();
+    }
+
+    protected abstract void configure();
+
+    protected static class BindToClass {
+        public void toInstance(Object object) {}
+    }
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/ConfigurationBuilder.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/ConfigurationBuilder.java
@@ -1,0 +1,17 @@
+package io.nuun.kernel.fluent;
+
+public interface ConfigurationBuilder {
+    ConfigurationBuilder after(Class<?> theClass);
+
+    ConfigurationBuilder before(Class<?> theClass);
+
+    ConfigurationBuilder scanClasses(Specification<?>... specification);
+
+    ConfigurationBuilder scanResources(String s);
+
+    ConfigurationBuilder bindClasses(Specification<?>... specification);
+
+    ConfigurationBuilder addPackageRoot(String s);
+
+    ConfigurationBuilder nextRound();
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/Factory.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/Factory.java
@@ -1,0 +1,4 @@
+package io.nuun.kernel.fluent;
+
+public interface Factory {
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/FluentPlugin.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/FluentPlugin.java
@@ -1,0 +1,11 @@
+package io.nuun.kernel.fluent;
+
+public interface FluentPlugin {
+    void configure(ConfigurationBuilder configurationBuilder);
+
+    void init(InitContext initContext, ModuleInstaller moduleInstaller);
+
+    void start();
+
+    void stop();
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/InitContext.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/InitContext.java
@@ -1,0 +1,14 @@
+package io.nuun.kernel.fluent;
+
+import java.net.URL;
+import java.util.Collection;
+
+public interface InitContext {
+    <T> T trait(Class<T> traitClass);
+
+    Collection<URL> resources(String regex);
+
+    <T> Collection<Class<? extends T>> classes(Specification<Class<? extends T>> spec);
+
+    void round(Round round);
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/InitState.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/InitState.java
@@ -1,0 +1,6 @@
+package io.nuun.kernel.fluent;
+
+public enum InitState {
+    INITIALIZED,
+    NOT_INITIALIZED
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/ModuleInstaller.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/ModuleInstaller.java
@@ -1,0 +1,5 @@
+package io.nuun.kernel.fluent;
+
+public interface ModuleInstaller {
+    void install(Object object);
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/MyFactory.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/MyFactory.java
@@ -1,0 +1,4 @@
+package io.nuun.kernel.fluent;
+
+public interface MyFactory extends Factory {
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/MyFactoryImpl.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/MyFactoryImpl.java
@@ -1,0 +1,4 @@
+package io.nuun.kernel.fluent;
+
+public class MyFactoryImpl implements MyFactory {
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/MyImplementationSpecification.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/MyImplementationSpecification.java
@@ -1,0 +1,23 @@
+package io.nuun.kernel.fluent;
+
+public class MyImplementationSpecification implements Specification<Class<? extends Factory>>{
+    @Override
+    public boolean isSatisfiedBy(Class<? extends Factory> aClass) {
+        return false;
+    }
+
+    @Override
+    public Specification<Class<? extends Factory>> and(Specification<? super Class<? extends Factory>> specification) {
+        return null;
+    }
+
+    @Override
+    public Specification<Class<? extends Factory>> or(Specification<? super Class<? extends Factory>> specification) {
+        return null;
+    }
+
+    @Override
+    public Specification<Class<? extends Factory>> not() {
+        return null;
+    }
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/MyInterfaceSpecification.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/MyInterfaceSpecification.java
@@ -1,0 +1,23 @@
+package io.nuun.kernel.fluent;
+
+public class MyInterfaceSpecification implements Specification<Class<? extends Factory>> {
+    @Override
+    public boolean isSatisfiedBy(Class<? extends Factory> aClass) {
+        return false;
+    }
+
+    @Override
+    public Specification<Class<? extends Factory>> and(Specification<? super Class<? extends Factory>> specification) {
+        return null;
+    }
+
+    @Override
+    public Specification<Class<? extends Factory>> or(Specification<? super Class<? extends Factory>> specification) {
+        return null;
+    }
+
+    @Override
+    public Specification<Class<? extends Factory>> not() {
+        return null;
+    }
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/PrivateModule.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/PrivateModule.java
@@ -1,0 +1,13 @@
+package io.nuun.kernel.fluent;
+
+public abstract class PrivateModule {
+    protected BindToClass bind(final Class<?> aClass) {
+        return new BindToClass();
+    }
+
+    protected abstract void configure();
+
+    protected static class BindToClass {
+        public void to(final Class<?> anotherClass) {}
+    }
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/Round.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/Round.java
@@ -1,0 +1,5 @@
+package io.nuun.kernel.fluent;
+
+public interface Round {
+    void execute();
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/SomeOtherTrait.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/SomeOtherTrait.java
@@ -1,0 +1,4 @@
+package io.nuun.kernel.fluent;
+
+public class SomeOtherTrait {
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/SomeTrait.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/SomeTrait.java
@@ -1,0 +1,5 @@
+package io.nuun.kernel.fluent;
+
+public interface SomeTrait {
+    void doSomething();
+}

--- a/pep_003_poc/io/nuun/kernel/fluent/Specification.java
+++ b/pep_003_poc/io/nuun/kernel/fluent/Specification.java
@@ -1,0 +1,11 @@
+package io.nuun.kernel.fluent;
+
+public interface Specification<T> {
+    boolean isSatisfiedBy(Class<? extends Factory> aClass);
+
+    Specification<Class<? extends Factory>> and(Specification<? super Class<? extends Factory>> specification);
+
+    Specification<Class<? extends Factory>> or(Specification<? super Class<? extends Factory>> specification);
+
+    Specification<Class<? extends Factory>> not();
+}


### PR DESCRIPTION
This PEP is about a new fluent API for plugins which could complement the traditional API (modernized with PEP 002 or not). This new API make uses of one-method interfaces to enable lambda coding in the plugins themselves. The API is still backwards compatible with Java 6 & 7.

The result is a drastic reduction of boilerplate code and a simplification of the plugin interface (named FluentPlugin in this pep). The use of "closures" and the ability to install modules directly from the init method enable to avoid keeping state in the plugin itself.
